### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -129,7 +129,7 @@ QString GameSkyrimVR::description() const
 
 MOBase::VersionInfo GameSkyrimVR::version() const
 {
-  return VersionInfo(1, 4, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameSkyrimVR::settings() const

--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -143,7 +143,6 @@ void GameSkyrimVR::initializeProfile(const QDir &path, ProfileSettings settings)
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Skyrim VR", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Skyrim VR", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.