### PR TITLE
Remove Enderal settings & Add ParticleLights to valid data directories

### DIFF
--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -201,7 +201,7 @@ QStringList GameSkyrimVR::primarySources() const
 
 QStringList GameSkyrimVR::validShortNames() const
 {
-  QStringList shortNames{ "Skyrim", "SkyrimSE" };
+QStringList shortNames{ "Skyrim", "SkyrimSE", "Enderal", "EnderalSE" };
   return shortNames;
 }
 

--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -134,10 +134,7 @@ MOBase::VersionInfo GameSkyrimVR::version() const
 
 QList<PluginSetting> GameSkyrimVR::settings() const
 {
-    return QList<PluginSetting>() << PluginSetting(
-        "enderal_downloads",
-        tr("Allow Enderal and EnderalSE downloads."),
-        true);
+  return {}; //Must return something, otherwise linker errors smh
 }
 
 void GameSkyrimVR::initializeProfile(const QDir &path, ProfileSettings settings) const

--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -134,7 +134,10 @@ MOBase::VersionInfo GameSkyrimVR::version() const
 
 QList<PluginSetting> GameSkyrimVR::settings() const
 {
-  return {}; //Must return something, otherwise linker errors smh
+    return QList<PluginSetting>() << PluginSetting(
+        "enderal_downloads",
+        tr("Allow Enderal and EnderalSE downloads."),
+        true);
 }
 
 void GameSkyrimVR::initializeProfile(const QDir &path, ProfileSettings settings) const

--- a/src/gameskyrimvr.cpp
+++ b/src/gameskyrimvr.cpp
@@ -134,9 +134,7 @@ MOBase::VersionInfo GameSkyrimVR::version() const
 
 QList<PluginSetting> GameSkyrimVR::settings() const
 {
-  return {
-    PluginSetting("enderal_downloads", "allow Enderal and Enderal SE downloads", QVariant(false))
-  };
+  return {}; //Must return something, otherwise linker errors smh
 }
 
 void GameSkyrimVR::initializeProfile(const QDir &path, ProfileSettings settings) const
@@ -204,9 +202,6 @@ QStringList GameSkyrimVR::primarySources() const
 QStringList GameSkyrimVR::validShortNames() const
 {
   QStringList shortNames{ "Skyrim", "SkyrimSE" };
-  if (m_Organizer->pluginSetting(name(), "enderal_downloads").toBool()) {
-    shortNames.append({ "Enderal", "EnderalSE" });
-  }
   return shortNames;
 }
 

--- a/src/skyrimvrmoddatachecker.h
+++ b/src/skyrimvrmoddatachecker.h
@@ -29,4 +29,4 @@ protected:
     }
 };
 
-#endif  // SKYRIMVR_MODATACHECKER_H
+#endif // SKYRIMVR_MODATACHECKER_H

--- a/src/skyrimvrmoddatachecker.h
+++ b/src/skyrimvrmoddatachecker.h
@@ -6,25 +6,27 @@
 class SkyrimVRModDataChecker : public GamebryoModDataChecker
 {
 public:
-  using GamebryoModDataChecker::GamebryoModDataChecker;
+    using GamebryoModDataChecker::GamebryoModDataChecker;
 
 protected:
-  virtual const FileNameSet& possibleFolderNames() const override {
-    static FileNameSet result{
-      "fonts", "interface", "menus", "meshes", "music", "scripts", "shaders",
-      "sound", "strings", "textures", "trees", "video", "facegen", "materials",
-      "skse", "distantlod", "asi", "Tools", "MCM", "distantland", "mits",
-      "dllplugins", "CalienteTools", "NetScriptFramework", "shadersfx",
-      "Nemesis_Engine"
-    };
-    return result;
-  }
-  virtual const FileNameSet& possibleFileExtensions() const override {
-    static FileNameSet result{
-      "esp", "esm", "bsa", "modgroups", "ini"
-    };
-    return result;
-  }
+    virtual const FileNameSet& possibleFolderNames() const override
+    {
+        static FileNameSet result{
+            "fonts",     "interface",      "menus",         "meshes",
+            "music",     "scripts",        "shaders",       "sound",
+            "strings",   "textures",       "trees",         "video",
+            "facegen",   "materials",      "skse",          "distantlod",
+            "asi",       "Tools",          "MCM",           "distantland",
+            "mits",      "dllplugins",     "CalienteTools", "NetScriptFramework",
+            "shadersfx", "Nemesis_Engine", "Platform",      "grass",
+            "ParticleLights"};
+        return result;
+    }
+    virtual const FileNameSet& possibleFileExtensions() const override
+    {
+        static FileNameSet result{ "esp", "esm", "esl", "bsa", "modgroups", "ini" };
+        return result;
+    }
 };
 
-#endif // SKYRIMVR_MODATACHECKER_H
+#endif  // SKYRIMVR_MODATACHECKER_H


### PR DESCRIPTION
# Authors
- @Ungeziefi
- @Senjay-id 

# Motivations
- There isn't much point to the Enderal settings when all it's used for is short-names
- The `ParticleLights` is a valid mod data directory